### PR TITLE
fix bug for syntax

### DIFF
--- a/packages/truffle-core/lib/commands/migrate.js
+++ b/packages/truffle-core/lib/commands/migrate.js
@@ -91,7 +91,7 @@ const command = {
     ]
   },
 
-  determineDryRunSettings: (config, options) => {
+  determineDryRunSettings: function(config, options) {
     // Source: ethereum.stackexchange.com/questions/17051
     const networkWhitelist = [
       1, // Mainnet (ETH & ETC)
@@ -181,7 +181,7 @@ const command = {
         const {
           dryRunOnly,
           dryRunAndMigrations
-        } = this.determineDryRunSettings(conf, options);
+        } = command.determineDryRunSettings(conf, options);
 
         if (dryRunOnly) {
           conf.dryRun = true;
@@ -191,7 +191,7 @@ const command = {
           conf.dryRun = true;
 
           await setupDryRunEnvironmentThenRunMigrations(conf);
-          let { config, proceed } = await this.prepareConfigForRealMigrations(
+          let { config, proceed } = await command.prepareConfigForRealMigrations(
             currentBuild,
             options
           );


### PR DESCRIPTION
In my macbook (node.js 11 ),  I have runing `truffle deploy --network ropsten` : 

```
TypeError: this.determineDryRunSettings is not a function
    at Contracts.compile.then (/Users/xingyuwang/.nvm/versions/node/v11.15.0/lib/node_modules/truffle/build/webpack:/packages/truffle-core/lib/commands/migrate.js:184:10)
```

fix it.